### PR TITLE
Imported division from __future__ for Python 2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Summary
 -------
 
 This is a port of Malcolm Slaney's and Dan Ellis' gammatone filterbank MATLAB
-code, detailed below, to Python 3 using Numpy and Scipy. It analyses signals by
+code, detailed below, to Python using Numpy and Scipy. It analyses signals by
 running them through banks of gammatone filters, similar to Fourier-based
 spectrogram analysis.
 
@@ -45,6 +45,8 @@ python setup.py install
  - nose
  - mock
  - matplotlib
+
+ Note: this library is compatible both with Python 2 and 3.
 
 Using the Code
 --------------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Summary
 -------
 
 This is a port of Malcolm Slaney's and Dan Ellis' gammatone filterbank MATLAB
-code, detailed below, to Python using Numpy and Scipy. It analyses signals by
+code, detailed below, to Python 2 and 3 using Numpy and Scipy. It analyses signals by
 running them through banks of gammatone filters, similar to Fourier-based
 spectrogram analysis.
 
@@ -45,8 +45,6 @@ python setup.py install
  - nose
  - mock
  - matplotlib
-
- Note: this library is compatible both with Python 2 and 3.
 
 Using the Code
 --------------

--- a/doc/details.rst
+++ b/doc/details.rst
@@ -5,7 +5,7 @@ Summary
 ~~~~~~~
 
 This is a port of Malcolm Slaney's and Dan Ellis' gammatone filterbank
-MATLAB code, detailed below, to Python using Numpy and Scipy. It
+MATLAB code, detailed below, to Python 2 and 3 using Numpy and Scipy. It
 analyses signals by running them through banks of gammatone filters,
 similar to Fourier-based spectrogram analysis.
 
@@ -23,8 +23,6 @@ Dependencies
 -  nose
 -  mock
 -  matplotlib
-
- Note: this library is compatible both with Python 2 and 3.
 
 Using the Code
 ~~~~~~~~~~~~~~

--- a/doc/details.rst
+++ b/doc/details.rst
@@ -5,7 +5,7 @@ Summary
 ~~~~~~~
 
 This is a port of Malcolm Slaney's and Dan Ellis' gammatone filterbank
-MATLAB code, detailed below, to Python 3 using Numpy and Scipy. It
+MATLAB code, detailed below, to Python using Numpy and Scipy. It
 analyses signals by running them through banks of gammatone filters,
 similar to Fourier-based spectrogram analysis.
 
@@ -23,6 +23,8 @@ Dependencies
 -  nose
 -  mock
 -  matplotlib
+
+ Note: this library is compatible both with Python 2 and 3.
 
 Using the Code
 ~~~~~~~~~~~~~~

--- a/gammatone/fftweight.py
+++ b/gammatone/fftweight.py
@@ -6,11 +6,11 @@
 This module contains functions for calculating weights to approximate a
 gammatone filterbank-like "spectrogram" from a Fourier transform.
 """
+from __future__ import division
 import numpy as np
 
 import gammatone.filters as filters
 import gammatone.gtgram as gtgram
-
 
 def specgram_window(
         nfft,

--- a/gammatone/filters.py
+++ b/gammatone/filters.py
@@ -6,6 +6,7 @@
 This module contains functions for constructing sets of equivalent rectangular
 bandwidth gammatone filters.
 """
+from __future__ import division
 from collections import namedtuple
 
 import numpy as np

--- a/gammatone/gtgram.py
+++ b/gammatone/gtgram.py
@@ -2,6 +2,7 @@
 # 
 # This file is part of the gammatone toolkit, and is licensed under the 3-clause
 # BSD license: https://github.com/detly/gammatone/blob/master/COPYING
+from __future__ import division
 import numpy as np
 
 from .filters import make_erb_filters, centre_freqs, erb_filterbank

--- a/gammatone/plot.py
+++ b/gammatone/plot.py
@@ -6,6 +6,7 @@
 Plotting utilities related to gammatone analysis, primarily for use with
 ``matplotlib``.
 """
+from __future__ import division
 import argparse
 import os.path
 

--- a/tests/test_fft_weights.py
+++ b/tests/test_fft_weights.py
@@ -3,6 +3,7 @@
 # 
 # This file is part of the gammatone toolkit, and is licensed under the 3-clause
 # BSD license: https://github.com/detly/gammatone/blob/master/COPYING
+from __future__ import division
 import nose
 import numpy as np
 import scipy.io


### PR DESCRIPTION
Turns out fixing this for Python 2 was very simple. The only issue was that in Python 2, the behaviour of the division operator `/` changes to integer division when both operands are integers. This pull request just adds `from __future__ import division` to all files to change this to the Python 3 behaviour (division is always float division). This does not need to be in a separate branch of the package, as this statement does nothing in Python 3, so the same codebase works both in Python 2 and 3.