### PR TITLE
FIX gtgram:  add f_max parameter

### DIFF
--- a/gammatone/filters.py
+++ b/gammatone/filters.py
@@ -72,7 +72,7 @@ def erb_space(
         )
 
 
-def centre_freqs(fs, num_freqs, cutoff):
+def centre_freqs(fs, num_freqs, cutoff, f_max=None):
     """
     Calculates an array of centre frequencies (for :func:`make_erb_filters`)
     from a sampling frequency, lower cutoff frequency and the desired number of
@@ -82,9 +82,12 @@ def centre_freqs(fs, num_freqs, cutoff):
     :param num_freqs: number of centre frequencies to calculate
     :type num_freqs: int
     :param cutoff: lower cutoff frequency
+    :param f_max: upper cutoff frequency (default ``fs / 2``)
     :return: same as :func:`erb_space`
     """
-    return erb_space(cutoff, fs / 2, num_freqs)
+    if f_max is None:
+        f_max = fs / 2
+    return erb_space(cutoff, f_max, num_freqs)
 
 
 def make_erb_filters(fs, centre_freqs, width=1.0):

--- a/gammatone/gtgram.py
+++ b/gammatone/gtgram.py
@@ -40,21 +40,16 @@ def gtgram_strides(fs, window_time, hop_time, filterbank_cols):
     return (nwin, hop_samples, columns)
 
 
-def gtgram_xe(wave, fs, channels, f_min):
+def gtgram_xe(wave, fs, channels, f_min, f_max):
     """ Calculate the intermediate ERB filterbank processed matrix """
-    cfs = centre_freqs(fs, channels, f_min)
+    cfs = centre_freqs(fs, channels, f_min, f_max)
     fcoefs = np.flipud(make_erb_filters(fs, cfs))
     xf = erb_filterbank(wave, fcoefs)
     xe = np.power(xf, 2)
     return xe
 
 
-def gtgram(
-    wave,
-    fs,
-    window_time, hop_time,
-    channels,
-    f_min):
+def gtgram(wave, fs, window_time, hop_time, channels, f_min, f_max=None):
     """
     Calculate a spectrogram-like time frequency magnitude array based on
     gammatone subband filters. The waveform ``wave`` (at sample rate ``fs``) is
@@ -68,7 +63,7 @@ def gtgram(
     |
     | (c) 2013 Jason Heeris (Python implementation)
     """
-    xe = gtgram_xe(wave, fs, channels, f_min)    
+    xe = gtgram_xe(wave, fs, channels, f_min, f_max)
     
     nwin, hop_samples, ncols = gtgram_strides(
         fs,


### PR DESCRIPTION
Hi there, I was glad to find this port! Not sure to what extent you're intending to fix issues in this repo, but `f_max` is in the documentation but missing from `gtgram()`. Might also rename `cutoff` in `centre_freqs` to `f_min` for consistency?